### PR TITLE
Fix memory leak caused by not freeing the values of `multis`

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -14,6 +14,9 @@ pub fn init(alloc: std.mem.Allocator) void {
 
 pub fn deinit() void {
     singles.deinit();
+    for (multis.values()) |array_list| {
+        array_list.deinit();
+    }
     multis.deinit();
 }
 


### PR DESCRIPTION
I caught this while using ziglint with the `file` flag.